### PR TITLE
Add ESTADO column to PAISES table

### DIFF
--- a/baseDatos/BaseDatosEsquemaTablas.sql
+++ b/baseDatos/BaseDatosEsquemaTablas.sql
@@ -27,7 +27,8 @@ create table PAISES
     ID_PAIS NUMBER generated as identity
         constraint PK_PAISES
             primary key,
-    NOMBRE  VARCHAR2(50) not null
+    NOMBRE  VARCHAR2(50) not null,
+    ESTADO  VARCHAR2(20) default 'ACTIVO' not null
 )
 /
 


### PR DESCRIPTION
## Summary
- add missing `ESTADO` column to `PAISES` table schema

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_686eb422d2ec832582a81c9d499568f0